### PR TITLE
fix float cmp

### DIFF
--- a/src/section.rs
+++ b/src/section.rs
@@ -1450,7 +1450,7 @@ fn parse_code_section(f: FunctionBody, environment: &mut Environment<'_, '_>) ->
             }
             Operator::F32Ne | Operator::F64Ne => {
                 numeric::helper_code_gen_comparison_float(
-                    inkwell::FloatPredicate::ONE,
+                    inkwell::FloatPredicate::UNE,
                     environment,
                 )
                 .expect("error gen compare float");


### PR DESCRIPTION
According to IEEE 754, comparisons involving NaN must always result in false. 
This PR fixes a bug where Wasker generates fcmp one, incorrectly returning true when one of the inputs is NaN.

```
one: yields true if both operands are not a QNAN and op1 is not equal to op2.
une: yields true if either operand is a QNAN or op1 is not equal to op2.
```