### PR TITLE
Add Environment::new to simplify

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -2,7 +2,6 @@
 
 use crate::environment::Environment;
 use crate::inkwell::init_inkwell;
-use crate::insts::control::UnreachableReason;
 use crate::section::translate_module;
 use anyhow::{anyhow, Context, Result};
 use clap::Parser;
@@ -39,34 +38,14 @@ pub fn compile_wasm(wasm: &[u8], args: &Args) -> Result<()> {
     let module = context.create_module("wasker_module");
     let builder = context.create_builder();
     let (inkwell_types, inkwell_insts) = init_inkwell(&context, &module);
-    let mut environment = Environment {
-        output_file: args.output_file.as_path(),
-        context: &context,
-        module: &module,
+    let mut environment = Environment::new(
+        args.output_file.as_path(),
+        &context,
+        &module,
         builder,
         inkwell_types,
         inkwell_insts,
-        function_signature_list: Vec::new(),
-        function_list: Vec::new(),
-        function_list_signature: Vec::new(),
-        function_list_name: Vec::new(),
-        stack: Vec::new(),
-        global: Vec::new(),
-        import_section_size: 0,
-        function_section_size: 0,
-        current_function_idx: u32::MAX,
-        control_frames: Vec::new(),
-        wasker_init_block: None,
-        wasker_main_block: None,
-        linear_memory_offset_global: None,
-        linear_memory_offset_int: None,
-        start_function_idx: None,
-        unreachable_depth: 0,
-        unreachable_reason: UnreachableReason::Reachable,
-        global_table: None,
-        global_memory_size: None,
-        fn_memory_grow: None,
-    };
+    );
 
     // translate wasm to LLVM IR
     translate_module(wasm, &mut environment)?;

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -81,6 +81,44 @@ pub struct Environment<'a, 'b> {
 }
 
 impl<'a, 'b> Environment<'a, 'b> {
+    pub fn new(
+        output_file: &'b Path,
+        context: &'a Context,
+        module: &'b Module<'a>,
+        builder: Builder<'a>,
+        inkwell_types: InkwellTypes<'a>,
+        inkwell_insts: InkwellInsts<'a>,
+    ) -> Self {
+        Self {
+            output_file,
+            context,
+            module,
+            builder,
+            inkwell_types,
+            inkwell_insts,
+            function_signature_list: Vec::new(),
+            function_list: Vec::new(),
+            function_list_signature: Vec::new(),
+            function_list_name: Vec::new(),
+            stack: Vec::new(),
+            global: Vec::new(),
+            import_section_size: 0,
+            function_section_size: 0,
+            current_function_idx: u32::MAX,
+            control_frames: Vec::new(),
+            wasker_init_block: None,
+            wasker_main_block: None,
+            linear_memory_offset_global: None,
+            linear_memory_offset_int: None,
+            start_function_idx: None,
+            unreachable_depth: 0,
+            unreachable_reason: UnreachableReason::Reachable,
+            global_table: None,
+            global_memory_size: None,
+            fn_memory_grow: None,
+        }
+    }
+
     /// Restore the stack to the specified size.
     pub fn reset_stack(&mut self, stack_size: usize) {
         self.stack.truncate(stack_size);


### PR DESCRIPTION
I want to add `Default::default()` but I found out it's tough because of types 😭 
Instead of `Default::default(), I added a `new` function to simplify a bit.