### PR TITLE
Fix memory base type in WASI wrapper rust example

### DIFF
--- a/examples/wasi-wrapper/rust/build.rs
+++ b/examples/wasi-wrapper/rust/build.rs
@@ -17,21 +17,13 @@ fn main() {
         .status()
         .expect("failed to compile target into WASM");
     Command::new("wasker")
-        .args([
-            "-o",
-            &target_obj_name,
-            "target/wasm32-wasi/debug/rust.wasm",
-        ])
+        .args(["-o", &target_obj_name, "target/wasm32-wasi/debug/rust.wasm"])
         .status()
         .expect("failed to compile target into obj");
 
     let target_lib_name = format!("lib{}.a", target_name);
     Command::new("ar")
-        .args([
-            "rcs",
-            &target_lib_name,
-            &target_obj_name,
-        ])
+        .args(["rcs", &target_lib_name, &target_obj_name])
         .status()
         .expect("failed to convert obj into lib");
 

--- a/examples/wasi-wrapper/rust/src/memory.rs
+++ b/examples/wasi-wrapper/rust/src/memory.rs
@@ -9,28 +9,28 @@ static LINEAR_MEMORY_BLOCK_NUM: Mutex<i32> = Mutex::new(0);
 
 #[inline]
 pub unsafe fn get_memory_base() -> *mut u8 {
-    unsafe { LINEAR_MEMORY_BASE }
+    LINEAR_MEMORY_BASE
 }
 
 unsafe fn alloc_memory() -> *mut u8 {
     use std::alloc::{alloc, Layout};
-    unsafe {
-        LINEAR_MEMORY_BASE = alloc(
-            Layout::from_size_align(
-                (LINEAR_MEMORY_BLOCK_SIZE * LINEAR_MEMORY_BLOCK_NUM_MAX) as usize,
-                8,
-            )
-            .unwrap(),
-        );
-        LINEAR_MEMORY_BASE
-    }
+    LINEAR_MEMORY_BASE = alloc(
+        Layout::from_size_align(
+            (LINEAR_MEMORY_BLOCK_SIZE * LINEAR_MEMORY_BLOCK_NUM_MAX) as usize,
+            8,
+        )
+        .unwrap(),
+    );
+    LINEAR_MEMORY_BASE
 }
 
-// fn get_memory_block_num() -> i32 {
-//     LINEAR_MEMORY_BLOCK_NUM.lock().unwrap().clone()
-// }
+#[no_mangle]
+pub extern "C" fn memory_base() -> usize {
+    unsafe { alloc_memory() as usize }
+}
 
-fn inc_memory_block_num(block_num: i32) -> i32 {
+#[no_mangle]
+pub extern "C" fn memory_grow(block_num: i32) -> i32 {
     assert!(
         block_num >= 0,
         "block_num must be greater than or equal to 0"
@@ -43,14 +43,4 @@ fn inc_memory_block_num(block_num: i32) -> i32 {
     }
     *num += block_num;
     old_val
-}
-
-#[no_mangle]
-pub extern "C" fn memory_base() -> i32 {
-    unsafe { alloc_memory() as i32 }
-}
-
-#[no_mangle]
-pub extern "C" fn memory_grow(block_num: i32) -> i32 {
-    inc_memory_block_num(block_num)
 }


### PR DESCRIPTION
I used `i32` as the return type for `memory_base`... well, that's wrong and can cause segmentation fault in some cases.