### PR TITLE
chore: fix lint error

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -115,11 +115,11 @@ fn get_host_target_machine() -> Result<targets::TargetMachine, String> {
     use targets::*;
 
     Target::initialize_native(&InitializationConfig::default())
-        .map_err(|e| format!("failed to initialize native target: {}", e))?;
+        .map_err(|e| format!("failed to initialize native target: {e}"))?;
 
     let triple = TargetMachine::get_default_triple();
     let target =
-        Target::from_triple(&triple).map_err(|e| format!("failed to get target: {}", e))?;
+        Target::from_triple(&triple).map_err(|e| format!("failed to get target: {e}"))?;
 
     let cpu = TargetMachine::get_host_cpu_name();
     let features = TargetMachine::get_host_cpu_features();

--- a/src/section.rs
+++ b/src/section.rs
@@ -438,7 +438,7 @@ fn parse_global_section(
     // These functions will be registerd in ExportSection
     for (i, global) in globals.into_iter().enumerate() {
         let global = global?;
-        let gname = format!("global_{}", i);
+        let gname = format!("global_{i}");
         let ty = wasmparser_to_inkwell(&global.ty.content_type, &environment.inkwell_types)?;
 
         // Get initial value

--- a/tests/spec.rs
+++ b/tests/spec.rs
@@ -9,8 +9,8 @@ fn _run_spec_test(testname: &str) {
 
     // read wast
     let mut wat = String::new();
-    let wat_path = std::path::Path::new(path).join(format!("{}.wast", testname));
-    println!("open file: {:?}", wat_path);
+    let wat_path = std::path::Path::new(path).join(format!("{testname}.wast"));
+    println!("open file: {wat_path:?}");
     let mut file = std::fs::File::open(wat_path).expect("error open file");
     file.read_to_string(&mut wat).expect("cannot read file");
 
@@ -30,7 +30,7 @@ fn _run_spec_test(testname: &str) {
                 file.flush().expect("fail to flush");
 
                 // Compile test
-                println!("Compile Module {:?}", name);
+                println!("Compile Module {name:?}");
                 let args = compiler::Args {
                     input_file: "tmp.wasm".into(),
                     output_file: "/tmp/wasm.o".into(),


### PR DESCRIPTION
In rust-1.88, clippy causes error at these points.