### PR TITLE
Replace all debug!() calls with trace!()

### DIFF
--- a/src/insts/control.rs
+++ b/src/insts/control.rs
@@ -354,7 +354,7 @@ pub(super) fn gen_br_table(environment: &mut Environment<'_, '_>, targets: &BrTa
     let values = environment.peekn(phis.len()).expect("fail stack peekn");
     for (i, phi) in phis.iter().enumerate().rev() {
         let value = values[i];
-        log::debug!("- add_incoming to {phi:?}");
+        log::trace!("- add_incoming to {phi:?}");
         phi.add_incoming(&[(&value, current_block)]);
     }
 
@@ -378,7 +378,7 @@ pub(super) fn gen_br_table(environment: &mut Environment<'_, '_>, targets: &BrTa
         for (i, phi) in phis.iter().enumerate().rev() {
             let value = values[i];
             phi.add_incoming(&[(&value, current_block)]);
-            log::debug!("- add_incoming to {phi:?}");
+            log::trace!("- add_incoming to {phi:?}");
         }
     }
     // switch
@@ -498,13 +498,13 @@ pub(super) fn gen_end<'a>(
         // Phi
         for phi in &end_phis {
             if phi.count_incoming() == 0 {
-                log::debug!("- no phi");
+                log::trace!("- no phi");
                 let basic_ty = phi.as_basic_value().get_type();
                 let placeholder_value = basic_ty.const_zero();
                 environment.stack.push(placeholder_value);
                 phi.as_instruction().erase_from_basic_block();
             } else {
-                log::debug!("- phi.incoming = {}", phi.count_incoming());
+                log::trace!("- phi.incoming = {}", phi.count_incoming());
                 let value = phi.as_basic_value();
                 environment.stack.push(value);
             }

--- a/src/insts/mod.rs
+++ b/src/insts/mod.rs
@@ -21,7 +21,7 @@ pub(super) fn parse_instruction<'a>(
     locals: &[(PointerValue<'a>, BasicTypeEnum<'a>)],
 ) -> Result<()> {
     if environment.unreachable_depth != 0 {
-        log::debug!("- under unreachable");
+        log::trace!("- under unreachable");
 
         match op {
             Operator::Block { blockty: _ }
@@ -35,7 +35,7 @@ pub(super) fn parse_instruction<'a>(
                     control::gen_else(environment).context("error gen Else")?;
                     environment.unreachable_depth -= 1;
                     environment.unreachable_reason = UnreachableReason::Reachable;
-                    log::debug!("- end of unreachable");
+                    log::trace!("- end of unreachable");
                     return Ok(());
                 } else {
                     return Ok(());
@@ -49,7 +49,7 @@ pub(super) fn parse_instruction<'a>(
                     control::gen_end(environment, current_fn).context("error gen End")?;
                     environment.unreachable_depth -= 1;
                     environment.unreachable_reason = UnreachableReason::Reachable;
-                    log::debug!("- end of unreachable");
+                    log::trace!("- end of unreachable");
                     return Ok(());
                 }
                 2_u32..=u32::MAX => {
@@ -89,7 +89,7 @@ pub(super) fn parse_instruction<'a>(
             control::gen_br_table(environment, targets).context("error gen BrTable")?;
         }
         Operator::End => {
-            log::debug!(
+            log::trace!(
                 "- gen_end, fn = {:?}, ret = {:?}",
                 current_fn.get_name(),
                 current_fn.get_type().get_return_type()


### PR DESCRIPTION
The current implementation logs all instruction with debug log. But it's too detailed so it buries other logs when calling wasker from other codes. I think trace log is better.