### PR TITLE
Use memmove for Wasm's memory.copy

### DIFF
--- a/src/insts/memory.rs
+++ b/src/insts/memory.rs
@@ -89,9 +89,9 @@ pub fn memory_copy(
     );
     environment
         .builder
-        .build_memcpy(dst_addr, 1, src_addr, 1, len.into_int_value())
+        .build_memmove(dst_addr, 1, src_addr, 1, len.into_int_value())
         .map_err(|e| anyhow!(e))
-        .context("error build_memcpy")?;
+        .context("error build_memmove")?;
     Ok(())
 }
 


### PR DESCRIPTION
WebAssembly memory.copy is specified with memmove semantics: when the source and destination regions overlap, the result must match copying via a temporary buffer. The compiler previously lowered this instruction to @llvm.memcpy, which assumes non-overlapping regions and is undefined behavior when they overlap.

This PR lowers memory.copy to @llvm.memmove instead.

ref: https://github.com/WebAssembly/spec/blob/main/proposals/bulk-memory-operations/Overview.md#memorycopy-instruction

> Copying takes place as if an intermediate buffer were used, allowing the destination and source to overlap.